### PR TITLE
run ci only on ubuntu 20.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       ALLOWED_HOSTS: localhost
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         python-version: ['3.10.2']
 
     steps:


### PR DESCRIPTION
this is a workaround for:
Error: Version X with arch x64 not found